### PR TITLE
Proposed Update to the linux32 build process (Adapted based on your file breakout on 2020-10-09)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -251,6 +251,7 @@ Steamworks/
 
 # Intermediate file on Mac/Linux:
 Steamworks.gml/Steamworks.gml.o
+Steamworks.gml/linux32
 
 # Auto-synced files:
 Steamworks.gmx/extensions/Steamworks.gml/Steamworks.gml.cpp

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Steamworks' `Readme.txt` should be located at `Steamworks/Readme.txt` as result.
 **Windows:** Open the included Visual Studio solution and order it to make a x86 build.
 
 **Linux:** Run build_linux_gms#.sh. You'll need cpp:i386, gcc:i386, and g++:i386 installed.
+```bash
+make release_linux32 STEAMWORKS_SDK=../../Steamworks
+```
 
 **Mac OSX:** Run build_osx_gms#.sh. You'll need XCode command line tools installed.
 

--- a/Steamworks.gml/Steamworks.gml.vcxproj
+++ b/Steamworks.gml/Steamworks.gml.vcxproj
@@ -90,13 +90,13 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>false</SDLCheck>
-      <AdditionalIncludeDirectories>./../Steamworks/public</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(STEAMWORKS_SDK)/public/steam</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>./../Steamworks/redistributable_bin;./../Steamworks/public/;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(STEAMWORKS_SDK)/redistributable_bin;$(STEAMWORKS_SDK)/public/;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>steam_api.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>

--- a/Steamworks.gml/steam_glue.h
+++ b/Steamworks.gml/steam_glue.h
@@ -21,8 +21,8 @@
 // Might be a conflict with GM runtime.
 #define VERSION_SAFE_STEAM_API_INTERFACES 1
 #define _CRT_SECURE_NO_WARNINGS
-#include "./../Steamworks/public/steam/steam_api.h"
-#include "./../Steamworks/public/steam/isteamappticket.h"
+#include "steam_api.h"
+#include "isteamappticket.h"
 
 // The following are solely in case it is ever needed to switch to "unsafe" API
 extern CSteamAPIContext SteamAPI;

--- a/build_linux_gms1.sh
+++ b/build_linux_gms1.sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-g++ -m32 -O3 -fPIC -g -c -o Steamworks.gml/Steamworks.gml.o Steamworks.gml/Steamworks.gml.cpp
-g++ -m32 Steamworks.gml/Steamworks.gml.o -shared -o Steamworks.gmx/extensions/Steamworks.gml/Steamworks.gml.so -Wl,-rpath,assets/ -LSteamworks/redistributable_bin/linux32 -lsteam_api
+make release_linux32 STEAMWORKS_SDK=../../Steamworks

--- a/makefile
+++ b/makefile
@@ -1,0 +1,82 @@
+CXX = g++
+LD = g++
+
+STEAMWORKS_SDK = #Path to the steamworks sdk as set in the GMS2 properties
+
+INC = 
+CFLAGS =  -std=c++11
+LIBDIR = 
+LIB = 
+LDFLAGS =
+
+SRCDIR = ./Steamworks.gml
+OBJDIR_RELEASE_LINUX32 = ./Steamworks.gml/linux32/obj/release
+OUTDIR_RELEASE_LINUX32 = ./Steamworks.gml/linux32/bin/release
+INC_RELEASE_LINUX32 = $(INC) -I$(STEAMWORKS_SDK)/public/steam
+CFLAGS_RELEASE_LINUX32 =  $(CFLAGS) -O3 -m32 -DNDEBUG -D_EG_LINUX_PLATFORM
+LIB_RELEASE_LINUX32 = -lsteam_api
+LIBDIR_RELEASE_LINUX32 =  $(LIBDIR) -L$(STEAMWORKS_SDK)/redistributable_bin/linux32
+LDFLAGS_RELEASE_LINUX32 =  $(LDFLAGS) -shared -m32 -Wl,-rpath,assets/
+
+OBJ_RELEASE_LINUX32 = $(OBJDIR_RELEASE_LINUX32)/gml_glue.o\
+					  $(OBJDIR_RELEASE_LINUX32)/steam_callbacks.o\
+					  $(OBJDIR_RELEASE_LINUX32)/steam_controller.o\
+					  $(OBJDIR_RELEASE_LINUX32)/steam_matchmaking.o\
+					  $(OBJDIR_RELEASE_LINUX32)/steam_networking.o\
+					  $(OBJDIR_RELEASE_LINUX32)/steam_unsorted.o\
+					  $(OBJDIR_RELEASE_LINUX32)/steam_user.o\
+					  $(OBJDIR_RELEASE_LINUX32)/steam_workshop.o
+
+OUT_RELEASE_LINUX32 = $(OUTDIR_RELEASE_LINUX32)/Steamworks.gml.so
+
+default: release
+
+release: release_linux32
+
+clean: clean_release_linux32
+
+before_release_linux32: 
+	test -d $(OUTDIR_RELEASE_LINUX32) || mkdir -p $(OUTDIR_RELEASE_LINUX32)
+	test -d $(OBJDIR_RELEASE_LINUX32) || mkdir -p $(OBJDIR_RELEASE_LINUX32)
+
+after_release_linux32: copy_release_linux32_topackage
+
+release_linux32: before_release_linux32 out_release_linux32 after_release_linux32
+
+out_release_linux32: before_release_linux32 $(OBJ_RELEASE_LINUX32) $(DEP_RELEASE_LINUX32)
+	$(LD) $(LIBDIR_RELEASE_LINUX32) -o $(OUT_RELEASE_LINUX32) $(OBJ_RELEASE_LINUX32)  $(LDFLAGS_RELEASE_LINUX32) $(LIB_RELEASE_LINUX32)
+
+$(OBJDIR_RELEASE_LINUX32)/gml_glue.o: $(SRCDIR)/gml_glue.cpp
+	$(CXX) $(CFLAGS_RELEASE_LINUX32) $(INC_RELEASE_LINUX32) -c $(SRCDIR)/gml_glue.cpp -o $(OBJDIR_RELEASE_LINUX32)/gml_glue.o
+
+$(OBJDIR_RELEASE_LINUX32)/steam_callbacks.o: $(SRCDIR)/steam_callbacks.cpp
+	$(CXX) $(CFLAGS_RELEASE_LINUX32) $(INC_RELEASE_LINUX32) -c $(SRCDIR)/steam_callbacks.cpp -o $(OBJDIR_RELEASE_LINUX32)/steam_callbacks.o
+
+$(OBJDIR_RELEASE_LINUX32)/steam_controller.o: $(SRCDIR)/steam_controller.cpp
+	$(CXX) $(CFLAGS_RELEASE_LINUX32) $(INC_RELEASE_LINUX32) -c $(SRCDIR)/steam_controller.cpp -o $(OBJDIR_RELEASE_LINUX32)/steam_controller.o
+
+$(OBJDIR_RELEASE_LINUX32)/steam_matchmaking.o: $(SRCDIR)/steam_matchmaking.cpp
+	$(CXX) $(CFLAGS_RELEASE_LINUX32) $(INC_RELEASE_LINUX32) -c $(SRCDIR)/steam_matchmaking.cpp -o $(OBJDIR_RELEASE_LINUX32)/steam_matchmaking.o
+
+$(OBJDIR_RELEASE_LINUX32)/steam_networking.o: $(SRCDIR)/steam_networking.cpp
+	$(CXX) $(CFLAGS_RELEASE_LINUX32) $(INC_RELEASE_LINUX32) -c $(SRCDIR)/steam_networking.cpp -o $(OBJDIR_RELEASE_LINUX32)/steam_networking.o
+
+$(OBJDIR_RELEASE_LINUX32)/steam_unsorted.o: $(SRCDIR)/steam_unsorted.cpp
+	$(CXX) $(CFLAGS_RELEASE_LINUX32) $(INC_RELEASE_LINUX32) -c $(SRCDIR)/steam_unsorted.cpp -o $(OBJDIR_RELEASE_LINUX32)/steam_unsorted.o
+
+$(OBJDIR_RELEASE_LINUX32)/steam_user.o: $(SRCDIR)/steam_user.cpp
+	$(CXX) $(CFLAGS_RELEASE_LINUX32) $(INC_RELEASE_LINUX32) -c $(SRCDIR)/steam_user.cpp -o $(OBJDIR_RELEASE_LINUX32)/steam_user.o
+
+$(OBJDIR_RELEASE_LINUX32)/steam_workshop.o: $(SRCDIR)/steam_workshop.cpp
+	$(CXX) $(CFLAGS_RELEASE_LINUX32) $(INC_RELEASE_LINUX32) -c $(SRCDIR)/steam_workshop.cpp -o $(OBJDIR_RELEASE_LINUX32)/steam_workshop.o
+
+copy_release_linux32_topackage:
+	test -d ./Steamworks.gmx/extensions/Steamworks.gml || mkdir -p ./Steamworks.gmx/extensions/Steamworks.gml
+	test -d ./Steamworks_yy/extensions/Steamworks_gml || mkdir -p ./Steamworks_yy/extensions/Steamworks_gml
+	cp $(OUT_RELEASE_LINUX32) ./Steamworks.gmx/extensions/Steamworks.gml/
+	cp $(OUT_RELEASE_LINUX32) ./Steamworks_yy/extensions/Steamworks_gml/
+
+clean_release_linux32: 
+	rm -f $(OBJ_RELEASE_LINUX32) $(OUT_RELEASE_LINUX32)
+	rm -rf $(OUT_RELEASE_LINUX32)
+	rm -rf $(OBJDIR_RELEASE_LINUX32)


### PR DESCRIPTION
Proposed changes
* EnvironmentVariable for STEAMWORKS_SDK path
_I'm already testing using the 150 and the 142 so needed that update to build with either/or_

* use of make
_Faster build since only the changed .o needs regenerated._
_Trash and .o are now in the Steamworks.gml/linux32 subfolder._

**usage**
Build the linux32 release .so file using the given Steamworks sdk
```
make release_linux32 STEAMWORKS_SDK=../../Steamworks_142
```

Remove all trash and .o temporary files
```
make clean
```



